### PR TITLE
fix: check for shell without path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,9 +13,9 @@ case $ARCH in
         ;;
 esac
 
-if [ $SHELL = "/bin/bash" ]; then
+if [[ $SHELL =~ "bash" ]]; then
     shellRc="$HOME/.bashrc"
-elif [ $SHELL = "/bin/zsh" ]; then
+elif [[ $SHELL =~ "zsh" ]]; then
     shellRc="$HOME/.zshrc"
 else
     echo -e "\033[31mError.\033[0m Shell not supported: $SHELL"


### PR DESCRIPTION
I encountered this problem with the install script
`Error. Shell not supported: /usr/bin/zsh`
So here is a PR to check for shells without the path.