### PR TITLE
fix: stop dropping --user flag when filtering user units by name (#46)

### DIFF
--- a/main.go
+++ b/main.go
@@ -2869,11 +2869,11 @@ func (app *App) loadJournalLogs(serviceName string, newUpdate bool) {
 		}
 		// Фильтрация по юниту (unit)
 		if serviceName != "_all" && selectUnits != "systemJournals" {
-			args = []string{"--unit=" + serviceName}
+			args = append(args, "--unit="+serviceName)
 		}
 		// Фильтрация по полю (field)
 		if serviceName != "_all" && selectUnits == "systemJournals" {
-			args = []string{app.journalField + "=" + serviceName}
+			args = append(args, app.journalField+"="+serviceName)
 		}
 		// Фильтрация по порядковому номеру загрузки системы (boot)
 		args = append(args, "--boot="+app.journalBoot)


### PR DESCRIPTION
## Bug

Closes #46. When viewing logs for a specific user unit (selected from the User journals list), the constructed `journalctl` command omits `--user`, so journald returns no entries and the Logs panel shows `-- No entries --`. Reported by @bjarnesc on the issue thread on 2026-03-23 against v0.8.6.

@bjarnesc's log line in the issue:

```
time=2026-03-23T11:31:18.748+01:00 level=INFO msg="/usr/bin/journalctl --unit=someService.service --boot=all --priority=debug --no-pager --lines=10000" action="Reading logs from user units"
```

The `--user` flag is missing.

## Root cause

`loadJournalLogs` in `main.go` (`default` branch starting at line 2856) builds the args list:

```go
var args []string
// #46 Добавляем аргумент для пользовательских журналов
if app.selectUnits == "userUnits" {
    args = append(args, "--user")        // (1) appends --user
}
// Фильтрация по юниту (unit)
if serviceName != "_all" && selectUnits != "systemJournals" {
    args = []string{"--unit=" + serviceName}   // (2) REASSIGNS — wipes --user
}
// Фильтрация по полю (field)
if serviceName != "_all" && selectUnits == "systemJournals" {
    args = []string{app.journalField + "=" + serviceName}   // (3) REASSIGNS
}
```

When `selectUnits == "userUnits"` and a specific service is selected (`serviceName != "_all"`), step (1) appends `--user`, then step (2) **reassigns** `args` to a fresh slice containing only the unit filter. The previously-added `--user` is gone. The subsequent `args = append(args, ...)` lines (`--boot`, `--priority`, `--no-pager`, `--lines`) all build on top of that filter-only slice, hence the cmd shape @bjarnesc reported.

`serviceName == "_all"` skips both reassignments, so it works there. That fits the partial workaround feel of the issue — viewing all user logs works, viewing one specific user unit doesn't.

This regressed in 0.8.6's CHANGELOG entry "Changed flags' order for improved usability and consistency" (under Fixes), matching the maintainer's own comment in the issue thread: *"I see a mistake (changed the flag order when adding new ones) and I will fix it."*

## Fix

Replace the two `args = []string{...}` reassignments with `args = append(args, ...)`:

```diff
 		// Фильтрация по юниту (unit)
 		if serviceName != "_all" && selectUnits != "systemJournals" {
-			args = []string{"--unit=" + serviceName}
+			args = append(args, "--unit="+serviceName)
 		}
 		// Фильтрация по полю (field)
 		if serviceName != "_all" && selectUnits == "systemJournals" {
-			args = []string{app.journalField + "=" + serviceName}
+			args = append(args, app.journalField+"="+serviceName)
 		}
```

Two-line change. `--user` (and any other flag added before these branches) now survives. The `systemJournals` branch was never broken because `--user` is only added for `userUnits`, but switching it to `append` for symmetry makes the code robust against any future pre-existing flags.

## Testing notes

I do not have a Go toolchain on this box so I have not run `go build` / `go test` locally — verified the change syntactically by inspection. The change is `args = []string{X}` → `args = append(args, X)`, both standard Go list-building idioms. No imports change; no API change.

`TestLinuxJournal` in `main_test.go` exercises the userUnits path via `loadJournalLogs(serviceName, ...)` but doesn't assert on the constructed command string, so it didn't catch the regression. A follow-up could refactor the args-building into a separately-testable function (`buildJournalArgs(...) []string`) and add a unit test that asserts `--user` is present for userUnits + a specific service. Happy to put that up as a separate PR if you'd like — kept this one minimal so the bugfix is reviewable on its own.

cc @bjarnesc — this should restore user-unit log loading on 0.8.6+. If you can pull the branch (`gh pr checkout 56`-ish) and confirm, that'd be perfect.