### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snapcraft.yml
+++ b/.github/workflows/snapcraft.yml
@@ -12,6 +12,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Lifailon/lazyjournal/security/code-scanning/5](https://github.com/Lifailon/lazyjournal/security/code-scanning/5)

Add an explicit `permissions` block at the workflow root (top-level), so it applies to all jobs unless overridden. The minimal safe setting for this workflow is:

- `contents: read`

This preserves existing behavior:
- `actions/checkout` works with `contents: read`.
- `actions/upload-artifact` does not require repository write permission.
- Snapcraft publishing uses external credentials, not GitHub repo writes.

**Where to change:** `.github/workflows/snapcraft.yml`, directly after the `on:` block (or before `jobs:`) at top level.  
**No imports, methods, or dependencies are needed** (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
