### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ppa.yml
+++ b/.github/workflows/ppa.yml
@@ -38,6 +38,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Build deb package and push to PPA


### PR DESCRIPTION
Potential fix for [https://github.com/Lifailon/lazyjournal/security/code-scanning/4](https://github.com/Lifailon/lazyjournal/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is restricted to least privilege.  
Best fix here: set workflow-level permissions to:

- `contents: read`

This preserves current behavior (checkout still works) while preventing unintended broader token access.  
Edit `.github/workflows/ppa.yml` near the top-level keys, placing `permissions` after `on:` (or before `jobs:`) so it applies to all jobs unless overridden.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
