### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,6 +15,9 @@ jobs:
 
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
+    permissions:
+      contents: read
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Lifailon/lazyjournal/security/code-scanning/3](https://github.com/Lifailon/lazyjournal/security/code-scanning/3)

Add an explicit `permissions` block for the `pr_tg_report` job (the one currently missing permissions).  
Best minimal fix without changing behavior: set read-only baseline permissions for repository contents.

In `.github/workflows/pr-check.yml`, under:

- `jobs:`
- `pr_tg_report:`
- after its `if:` (or before `runs-on:`),

add:

```yml
permissions:
  contents: read
```

This keeps functionality unchanged while satisfying CodeQL by explicitly constraining token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
