### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,6 +40,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Docker build on ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Lifailon/lazyjournal/security/code-scanning/2](https://github.com/Lifailon/lazyjournal/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define workflow-level permissions immediately after `on:` (or after inputs block and before `jobs:`) with:

- `contents: read`

This preserves current functionality (`actions/checkout` keeps working) while preventing accidental broader permissions from defaults. No imports, methods, or dependencies are needed; this is a YAML config-only change in `.github/workflows/docker.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
