### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -12,6 +12,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   copr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Lifailon/lazyjournal/security/code-scanning/1](https://github.com/Lifailon/lazyjournal/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is limited by default.  
Best fix here: define workflow-level permissions with the minimal needed scope:

- `contents: read`

This preserves current behavior:
- `actions/checkout` works with `contents: read`.
- build steps do not need extra GitHub token scopes.
- `actions/upload-artifact` does not require repository write scopes via `GITHUB_TOKEN`.

Edit file **`.github/workflows/copr.yml`**, adding `permissions:` after the `on:` inputs block and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
